### PR TITLE
Implemented some more functions

### DIFF
--- a/src/IGraph/Algorithms/Structure.chs
+++ b/src/IGraph/Algorithms/Structure.chs
@@ -3,8 +3,10 @@
 module IGraph.Algorithms.Structure
     ( -- * Shortest Path Related Functions
       shortestPath
+    , averagePathLength
     , diameter
     , eccentricity
+    , radius
       -- * Graph Components
     , inducedSubgraph
     , isConnected
@@ -69,6 +71,23 @@ shortestPath gr s t getEdgeW = unsafePerformIO $ allocaVector $ \path -> do
     , `Neimode'
     } -> `CInt' void- #}
 
+-- | Calculates the average shortest path length between all vertex pairs.
+averagePathLength :: Graph d v e
+                  -> EdgeType -- ^ whether to consider directed paths
+                  -> Bool     -- ^ if unconnected,
+                              -- include only connected pairs (True)
+                              -- or return number if vertices (False)
+                  -> Double
+averagePathLength graph directed unconn =
+  cFloatConv $ igraphAveragePathLength (_graph graph) directed unconn
+{-# INLINE igraphAveragePathLength #-}
+{#fun pure igraph_average_path_length as ^
+    { `IGraph'
+    , alloca- `CDouble' peek*
+    , dirToBool `EdgeType'
+    , `Bool'
+    } -> `CInt' void- #}
+
 -- | Calculates the diameter of a graph (longest geodesic).
 diameter :: Graph d v e
          -> EdgeType -- ^ whether to consider directed paths
@@ -108,6 +127,19 @@ eccentricity graph mode vids = unsafePerformIO $
     { `IGraph'
     , castPtr `Ptr Vector'
     , castPtr %`Ptr VertexSelector'
+    , `Neimode'
+    } -> `CInt' void- #}
+
+-- | Radius of a graph.
+radius :: Graph d v e
+       -> Neimode -- ^ 'IgraphOut' to follow edges' direction,
+                  -- 'IgraphIn' to reverse it, 'IgraphAll' to ignore
+       -> Double
+radius graph mode = cFloatConv $ igraphRadius (_graph graph) mode
+{-# INLINE igraphRadius #-}
+{#fun pure igraph_radius as ^
+    { `IGraph'
+    , alloca- `CDouble' peek*
     , `Neimode'
     } -> `CInt' void- #}
 

--- a/src/IGraph/Algorithms/Structure.chs
+++ b/src/IGraph/Algorithms/Structure.chs
@@ -12,6 +12,9 @@ module IGraph.Algorithms.Structure
     , isConnected
     , isStronglyConnected
     , decompose
+    , articulationPoints
+    , bridges
+      -- * Topological Sorting, Directed Acyclic Graphs
     , isDag
     , topSort
     , topSortUnsafe
@@ -192,6 +195,27 @@ decompose gr = unsafePerformIO $ allocaVectorPtr $ \ptr -> do
     , `Int'
     } -> `CInt' void- #}
 
+-- | Find the articulation points in a graph.
+articulationPoints :: Graph d v e -> [Node]
+articulationPoints gr = unsafePerformIO $ allocaVector $ \res -> do
+  igraphArticulationPoints (_graph gr) res
+  toNodes res
+{-#INLINE igraphArticulationPoints #-}
+{#fun igraph_articulation_points as ^
+    { `IGraph'
+    , castPtr `Ptr Vector'
+    } -> `CInt' void- #}
+
+-- ^ Find all bridges in a graph.
+bridges :: Graph d v e -> [Edge]
+bridges gr = unsafePerformIO $ allocaVector $ \res -> do
+  igraphBridges (_graph gr) res
+  map (getEdgeByEid gr) <$> toNodes res
+{-# INLINE igraphBridges #-}
+{#fun igraph_bridges as ^
+    { `IGraph'
+    , castPtr `Ptr Vector'
+    } -> `CInt' void- #}
 
 -- | Checks whether a graph is a directed acyclic graph (DAG) or not.
 isDag :: Graph d v e -> Bool

--- a/src/IGraph/Algorithms/Structure.chs
+++ b/src/IGraph/Algorithms/Structure.chs
@@ -18,6 +18,9 @@ module IGraph.Algorithms.Structure
     , isDag
     , topSort
     , topSortUnsafe
+      -- * Other Operations
+    , density
+    , reciprocity
       -- * Auxiliary types
     , Neimode(IgraphOut,IgraphIn,IgraphAll) -- not IgraphTotal
     ) where
@@ -247,6 +250,34 @@ topSortUnsafe gr = unsafePerformIO $ allocaVectorN n $ \res -> do
     , castPtr `Ptr Vector'
     , `Neimode'
     } -> `CInt' void- #}
+
+-- | Calculate the density of a graph.
+density :: Graph d v e
+        -> Bool -- ^ whether to include loops
+        -> Double -- ^ the ratio of edges to possible edges
+density gr loops = unsafePerformIO $ alloca $ \res -> do
+  igraphDensity (_graph gr) res loops
+  peek res
+{-# INLINE igraphDensity #-}
+{#fun igraph_density as ^
+    { `IGraph'
+    , castPtr `Ptr Double'
+    , `Bool'
+    } -> `CInt' void -#}
+
+-- | Calculates the reciprocity of a directed graph.
+reciprocity :: Graph d v e
+            -> Bool -- ^ whether to ignore loop edges
+            -> Double -- ^ the proportion of mutual connections
+reciprocity gr ignore_loops = unsafePerformIO $ alloca $ \res -> do
+  igraphReciprocity (_graph gr) res ignore_loops IgraphReciprocityDefault
+  peek res
+{#fun igraph_reciprocity as ^
+    { `IGraph'
+    , castPtr `Ptr Double'
+    , `Bool'
+    , `Reciprocity'
+    } -> `CInt' void -#}
 
 -- Marshaller for those "treat edges as directed" booleans.
 dirToBool :: Num n => EdgeType -> n

--- a/src/IGraph/Algorithms/Structure.chs
+++ b/src/IGraph/Algorithms/Structure.chs
@@ -4,6 +4,8 @@ module IGraph.Algorithms.Structure
     ( -- * Shortest Path Related Functions
       shortestPath
     , diameter
+    , eccentricity
+      -- * Graph Components
     , inducedSubgraph
     , isConnected
     , isStronglyConnected
@@ -11,6 +13,8 @@ module IGraph.Algorithms.Structure
     , isDag
     , topSort
     , topSortUnsafe
+      -- * Auxiliary types
+    , Neimode(IgraphOut,IgraphIn,IgraphAll) -- not IgraphTotal
     ) where
 
 import           Control.Monad
@@ -86,6 +90,25 @@ diameter graph directed unconn = unsafePerformIO $
     , castPtr `Ptr Vector'
     , dirToBool `EdgeType'
     , `Bool'
+    } -> `CInt' void- #}
+
+-- | Eccentricity of some vertices.
+eccentricity :: Graph d v e
+             -> Neimode -- ^ 'IgraphOut' to follow edges' direction,
+                        -- 'IgraphIn' to reverse it, 'IgraphAll' to ignore
+             -> [Node]  -- ^ vertices for which to calculate eccentricity
+             -> [Double]
+eccentricity graph mode vids = unsafePerformIO $
+  allocaVector $ \res ->
+  withVerticesList vids $ \vs -> do
+    igraphEccentricity (_graph graph) res vs mode
+    toList res
+{-# INLINE igraphEccentricity #-}
+{#fun igraph_eccentricity as ^
+    { `IGraph'
+    , castPtr `Ptr Vector'
+    , castPtr %`Ptr VertexSelector'
+    , `Neimode'
     } -> `CInt' void- #}
 
 -- | Creates a subgraph induced by the specified vertices. This function collects

--- a/src/IGraph/Internal.chs
+++ b/src/IGraph/Internal.chs
@@ -8,6 +8,7 @@ module IGraph.Internal
     , withList
     , withListMaybe
     , toList
+    , toNodes
     , igraphVectorNull
     , igraphVectorFill
     , igraphVectorE
@@ -192,6 +193,10 @@ toList vec = do
         igraphVectorCopyTo vec ptr
         map realToFrac <$> peekArray n ptr
 {-# INLINE toList #-}
+
+toNodes :: Ptr Vector -> IO [Node]
+toNodes = fmap (map truncate) . toList
+{-# INLINE toNodes #-}
 
 {#fun igraph_vector_copy_to as ^ { castPtr `Ptr Vector', id `Ptr CDouble' } -> `()' #}
 

--- a/src/IGraph/Internal/Constants.chs
+++ b/src/IGraph/Internal/Constants.chs
@@ -41,3 +41,6 @@ module IGraph.Internal.Constants where
 
 {#enum igraph_degseq_t as Degseq {underscoreToCase}
     deriving (Show, Read, Eq) #}
+
+{#enum igraph_reciprocity_t as Reciprocity {underscoreToCase}
+    deriving (Show, Read, Eq) #}

--- a/tests/Test/Algorithms.hs
+++ b/tests/Test/Algorithms.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
 module Test.Algorithms
     ( tests
     ) where
@@ -20,6 +21,7 @@ tests = testGroup "Algorithms"
     [ graphIsomorphism
     , motifTest
     , cliqueTest
+    , diameterTest
     , subGraphs
     , decomposeTest
     , pagerankTest
@@ -54,6 +56,13 @@ cliqueTest = testGroup "Clique"
     c3 = [ [0,3,4], [0,4,5], [1,2,3], [1,2,4], [1,2,5], [1,3,4], [1,4,5],
         [2,3,4], [2,4,5] ]
     c4 = [[1, 2, 3, 4], [1, 2, 4, 5]]
+
+diameterTest :: TestTree
+diameterTest = testGroup "Diameters"
+    [ testCase "clique" $ fst (diameter (full @'U 10 False) U True)  @?= 1
+    , testCase "star"   $ fst (diameter (star 10)          D False) @?= 2
+    , testCase "ring"   $ fst (diameter (ring 10)          U False) @?= 5
+    ]
 
 subGraphs :: TestTree
 subGraphs = testGroup "generate induced subgraphs"

--- a/tests/Test/Algorithms.hs
+++ b/tests/Test/Algorithms.hs
@@ -31,6 +31,8 @@ tests = testGroup "Algorithms"
     , bridgeTest
     , pagerankTest
     , kleinbergTest
+    , densityTest
+    , reciprocityTest
     ]
 
 graphIsomorphism :: TestTree
@@ -169,6 +171,19 @@ kleinbergTest = testGroup "Kleinberg"
     , testCase "Authority score" $
         fst (authorityScore (ring 4) False) @?= replicate 4 0.5
     ]
+
+densityTest :: TestTree
+densityTest = testGroup "Density"
+    [ testCase "clique" $ density (full @'U 16 False) False @?= 1
+    , testCase "ring" $ density (ring 9) False @?= 1/4
+    ]
+
+reciprocityTest :: TestTree
+reciprocityTest = testGroup "Reciprocity"
+    [ testCase "clique" $ reciprocity (full @'D 10 False) False @?= 1
+    , testCase "ring" $ reciprocity g False @?= 0
+    ]
+  where g = fromLabeledEdges @'D [(("a","b"),()),(("b","c"),()),(("c","a"),())]
 
 -- approximate equality helper
 (@?~) :: (Ord n,Fractional n) => n -> n -> Assertion

--- a/tests/Test/Algorithms.hs
+++ b/tests/Test/Algorithms.hs
@@ -27,6 +27,8 @@ tests = testGroup "Algorithms"
     , radiusTest
     , subGraphs
     , decomposeTest
+    , articulationTest
+    , bridgeTest
     , pagerankTest
     , kleinbergTest
     ]
@@ -123,6 +125,18 @@ decomposeTest = testGroup "Decompose"
 		 , (3,4), (4,5), (5,6)
 		 , (8,9), (9,10) ]
     gr = mkGraph (replicate 11 ()) $ zip es $ repeat () :: Graph 'U () ()
+
+articulationTest :: TestTree
+articulationTest = testCase "Articulation points" $
+  articulationPoints (star 3) @?= [0]
+
+bridgeTest :: TestTree
+bridgeTest = testCase "Bridges" $ edgeLab g <$> bridges g @?= ["bridge"]
+  where g = fromLabeledEdges @'U
+            [ (("a","b"),"ab") , (("b","c"),"bc") , (("c","a"),"ca")
+            , (("i","j"),"ij") , (("j","k"),"jk") , (("k","i"),"ki")
+            , (("a","i"),"bridge")
+            ]
 
 {-
 communityTest :: TestTree

--- a/tests/Test/Algorithms.hs
+++ b/tests/Test/Algorithms.hs
@@ -28,6 +28,7 @@ tests = testGroup "Algorithms"
     , subGraphs
     , decomposeTest
     , pagerankTest
+    , kleinbergTest
     ]
 
 graphIsomorphism :: TestTree
@@ -146,6 +147,14 @@ pagerankTest = testGroup "PageRank"
     ranks = [0.47,0.05,0.05,0.05,0.05,0.05,0.05,0.05,0.05,0.05,0.05]
     ranks' = map ((/100) . fromIntegral . round. (*100)) $
         pagerank gr 0.85 Nothing Nothing
+
+kleinbergTest :: TestTree
+kleinbergTest = testGroup "Kleinberg"
+    [ testCase "Hub score" $
+        fst (hubScore (full @'U 16 False) True) @?= replicate 16 1
+    , testCase "Authority score" $
+        fst (authorityScore (ring 4) False) @?= replicate 4 0.5
+    ]
 
 -- approximate equality helper
 (@?~) :: (Ord n,Fractional n) => n -> n -> Assertion

--- a/tests/Test/Algorithms.hs
+++ b/tests/Test/Algorithms.hs
@@ -22,6 +22,7 @@ tests = testGroup "Algorithms"
     , motifTest
     , cliqueTest
     , diameterTest
+    , eccentricityTest
     , subGraphs
     , decomposeTest
     , pagerankTest
@@ -62,6 +63,16 @@ diameterTest = testGroup "Diameters"
     [ testCase "clique" $ fst (diameter (full @'U 10 False) U True)  @?= 1
     , testCase "star"   $ fst (diameter (star 10)          D False) @?= 2
     , testCase "ring"   $ fst (diameter (ring 10)          U False) @?= 5
+    ]
+
+eccentricityTest :: TestTree
+eccentricityTest = testGroup "Eccentricity"
+    [ testCase "clique" $
+        eccentricity (full @'U 10 False) IgraphAll [0..9] @?= replicate 10 1
+    , testCase "star" $
+        eccentricity (star 10) IgraphAll [0..9] @?= (1 : replicate 9 2)
+    , testCase "ring" $
+        eccentricity (ring 10) IgraphAll [0..9] @?= replicate 10 5
     ]
 
 subGraphs :: TestTree

--- a/tests/Test/Algorithms.hs
+++ b/tests/Test/Algorithms.hs
@@ -21,8 +21,10 @@ tests = testGroup "Algorithms"
     [ graphIsomorphism
     , motifTest
     , cliqueTest
+    , averagePathTest
     , diameterTest
     , eccentricityTest
+    , radiusTest
     , subGraphs
     , decomposeTest
     , pagerankTest
@@ -58,6 +60,13 @@ cliqueTest = testGroup "Clique"
         [2,3,4], [2,4,5] ]
     c4 = [[1, 2, 3, 4], [1, 2, 4, 5]]
 
+averagePathTest :: TestTree
+averagePathTest = testGroup "Average path lengths"
+    [ testCase "clique" $ averagePathLength (full @'U 10 False) U True @?= 1
+    , testCase "star" $ averagePathLength (star 10) U True @?~ 1.8
+    , testCase "ring" $ averagePathLength (ring 11) U True @?= 3
+    ]
+
 diameterTest :: TestTree
 diameterTest = testGroup "Diameters"
     [ testCase "clique" $ fst (diameter (full @'U 10 False) U True)  @?= 1
@@ -73,6 +82,13 @@ eccentricityTest = testGroup "Eccentricity"
         eccentricity (star 10) IgraphAll [0..9] @?= (1 : replicate 9 2)
     , testCase "ring" $
         eccentricity (ring 10) IgraphAll [0..9] @?= replicate 10 5
+    ]
+
+radiusTest :: TestTree
+radiusTest = testGroup "Radius"
+    [ testCase "clique" $ radius (full @'U 10 False) IgraphAll @?= 1
+    , testCase "star" $ radius (star 10) IgraphAll @?= 1
+    , testCase "ring" $ radius (ring 10) IgraphAll @?= 5
     ]
 
 subGraphs :: TestTree
@@ -130,3 +146,7 @@ pagerankTest = testGroup "PageRank"
     ranks = [0.47,0.05,0.05,0.05,0.05,0.05,0.05,0.05,0.05,0.05,0.05]
     ranks' = map ((/100) . fromIntegral . round. (*100)) $
         pagerank gr 0.85 Nothing Nothing
+
+-- approximate equality helper
+(@?~) :: (Ord n,Fractional n) => n -> n -> Assertion
+a @?~ b = assertBool "" $ abs (b-a) < 1/65536


### PR DESCRIPTION
Hi,

I've been using `haskell-igraph` for a side project of mine, and needed a few more functions, so I've added them.
Please help yourself if you're interested in pulling the changes.
(or let me know if something needs work)

I don't know how stable you intend the interfaces to remain; here were my design choices and stability thoughts as I wrote this:

* a few of those functions could benefit from return-type polymorphism in the long run (those with optional outputs that change the time complexity accordingly). Best example: `diameter`.
* I've exposed `Neimode` for some operations.  Its elements are really ugly (`IgraphOut` with the lowercase g, yuck).  Its type name isn't perfect either, surely `NeiMode` would be better.  I don't even know what NEI means.
* I've used `EdgeType` as a `Bool` substitute where I thought it made sense.
* it's the first time I touch c2hs, I've surely messed up something somewhere. I'm a bit scared of those `castPtr`.

Cheers